### PR TITLE
Version upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "prettier-config-ackee",
-	"version": "0.0.13",
+	"version": "0.0.14",
 	"description": "Shared Prettier configuration accross Ackee's projects.",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Version upgrade is required to make use of the latest commit `Merge pull request #4 from AckeeCZ/fix/be-arrow-parens`