### PR TITLE
🔧 Set tabWidth to 4 from default 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,4 +8,5 @@ module.exports = {
 	printWidth: 120,
 	jsxBracketSameLine: false,
 	trailingComma: 'all',
+	tabWidth: 4,
 };


### PR DESCRIPTION
`@ackee/eslint-config` enforces 4 spaces but the default prettier config value is set to 2. 